### PR TITLE
Use GenericImageView and GenericImage

### DIFF
--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -35,7 +35,9 @@ pub trait ImageBuffer {
 }
 
 #[cfg(feature = "img")]
-impl ImageBuffer for image::GrayImage {
+impl<T: image::GenericImage<Pixel = image::Luma<u8>>
+    + image::GenericImageView<Pixel = image::Luma<u8>>,
+    > ImageBuffer for T {
     fn width(&self) -> usize {
         self.width() as usize
     }


### PR DESCRIPTION
This removes the obligation to copy the image before processing it. This way we aren't forced to use a Vec<u8> as `Container` of the image.