### PR TITLE
Gracefully return an error instead of panicking with invalid (zero) error correction

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -412,6 +412,9 @@ fn correct_block(
         if poly_eval(&sigma, xinv) == GF256::ZERO {
             let sd_x = poly_eval(&sigma_deriv, xinv);
             let omega_x = poly_eval(&omega, xinv);
+            if sd_x == GF256::ZERO {
+                return Err(DeQRError::DataEcc);
+            }
             let error = omega_x / sd_x;
             block[ecc.bs - i - 1] = (GF256(block[ecc.bs - i - 1]) + error).0;
         }


### PR DESCRIPTION
**Background information**

A client was able to cause a crash in GF256's division when the denominator was zero. As it turns out, we aren't checking that condition so some (likely invalid) QR codes can crash decoding. 

Sadly I don't have access to and thus can supply the QR code that caused this crash (otherwise I would have added it as a test). I do however have a stack trace so I was able to identify the offending division.

See #20 for the stack trace.

Resolves #20 

**Reasoning/approach**

I've inspected all divisions in decode.rs and determined that only that one case could ever devide by zero. Other code paths either have an indirect check preventing them from becoming zero or are statically defined to non zero.

Since we already have a fallible return type, failing error correction seems like the ideal reaction to this invalid data. 