### PR TITLE
Make const MAX_PAYLOAD_SIZE public

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -9,7 +9,7 @@ use crate::{BitGrid, DeQRError, DeQRResult};
 g2p!(GF16, 4, modulus: 0b1_0011);
 g2p!(GF256, 8, modulus: 0b1_0001_1101);
 
-const MAX_PAYLOAD_SIZE: usize = 8896;
+pub const MAX_PAYLOAD_SIZE: usize = 8896;
 
 /// Version of a QR Code which determines its size
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]


### PR DESCRIPTION
Making the constant MAX_PAYLOAD_SIZE public, would allow the  expansion of structs, like DataStream, in another crate. Even though DataStream is declared public, having the private  constant as an attribute, makes it not possible to access it directly from another crate.

This small change would make expanding functionality much easier.