### PR TITLE
Fix example to use the correct image API

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The most basic usage is shown below:
 use image;
 use rqrr;
 
-let img = image::open("tests/data/github.gif")?.to_luma();
+let img = image::open("tests/data/github.gif")?.into_luma8();
 // Prepare for detection
 let mut img = rqrr::PreparedImage::prepare(img);
 // Search for grids, without decoding


### PR DESCRIPTION
Thanks @ahirner for finding this typo.  Also replace `to_` with `into_` to avoid doing a copy in case the input image is already in luma8 format.

Fixes #44.