### PR TITLE
Bump the lru crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,5 +39,5 @@ image = { version = ">= 0.24, <= 0.25", default-features = false, features = ["p
 
 [dependencies]
 g2p = "1.0"
-lru = "0.16"
+lru = "0.18"
 image = { version = ">= 0.24, <= 0.25", optional = true, default-features = false }


### PR DESCRIPTION
This was the only outdated crate remaining after a `cargo update`, and requires no code change whatsoever.