### PR TITLE
Make this crate `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,9 @@ include = [
 ]
 
 [features]
+std = []
 img = ["image"]
-default = ["img"]
+default = ["img", "std"]
 
 [[bench]]
 name = "bench_cap_find"

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,9 +1,10 @@
-use std::io::Write;
-use std::mem;
+use core::cmp;
+use core::mem;
 
 use g2p::{g2p, GaloisField};
 
 use crate::version_db::{RSParameters, VERSION_DATA_BASE};
+use crate::Write;
 use crate::{BitGrid, DeQRError, DeQRResult};
 
 g2p!(GF16, 4, modulus: 0b1_0011);
@@ -85,7 +86,7 @@ impl CorrectedDataStream {
 
     pub fn take_bits(&mut self, nbits: usize) -> usize {
         let mut ret = 0;
-        let max_len = ::std::cmp::min(self.bits_remaining(), nbits);
+        let max_len = cmp::min(self.bits_remaining(), nbits);
         assert!(max_len <= mem::size_of::<usize>() * 8);
         for _ in 0..max_len {
             let b = self.data[self.ptr >> 3];

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -4,6 +4,7 @@ use crate::{
     identify::Point,
     prepare::{ColoredRegion, PreparedImage, Row},
 };
+use alloc::vec::Vec;
 
 /// A locator pattern of a QR grid
 ///

--- a/src/identify/grid.rs
+++ b/src/identify/grid.rs
@@ -1,4 +1,4 @@
-use std::{cmp, mem};
+use core::{cmp, mem};
 
 use crate::{
     geometry,

--- a/src/identify/match_capstones.rs
+++ b/src/identify/match_capstones.rs
@@ -1,4 +1,5 @@
 use crate::CapStone;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 pub struct CapStoneGroup(pub CapStone, pub CapStone, pub CapStone);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,13 +34,42 @@ If you have some other form of picture storage, you can use
 you to define your own source for images.
 "##
 )]
+#![no_std]
+
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
 pub use self::decode::{MetaData, RawData, Version, MAX_PAYLOAD_SIZE};
 pub(crate) use self::detect::{capstones_from_image, CapStone};
 pub use self::identify::Point;
 pub(crate) use self::identify::SkewedGridLocation;
 pub use self::prepare::PreparedImage;
-use std::error::Error;
-use std::io::Write;
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::error::Error;
+use core::fmt;
+
+#[cfg(feature = "std")]
+pub use std::io::Write;
+#[cfg(not(feature = "std"))]
+pub trait Write {
+    fn write_all(&mut self, buf: &[u8]) -> Result<(), ()>;
+}
+#[cfg(not(feature = "std"))]
+impl Write for Vec<u8> {
+    fn write_all(&mut self, buf: &[u8]) -> Result<(), ()> {
+        self.extend_from_slice(buf);
+        Ok(())
+    }
+}
+#[cfg(not(feature = "std"))]
+impl<W: Write> Write for &mut W {
+    fn write_all(&mut self, buf: &[u8]) -> Result<(), ()> {
+        (*self).write_all(buf)
+    }
+}
 
 mod decode;
 mod detect;
@@ -312,14 +341,14 @@ type DeQRResult<T> = Result<T, DeQRError>;
 
 impl Error for DeQRError {}
 
-impl From<::std::string::FromUtf8Error> for DeQRError {
-    fn from(_: ::std::string::FromUtf8Error) -> Self {
+impl From<alloc::string::FromUtf8Error> for DeQRError {
+    fn from(_: alloc::string::FromUtf8Error) -> Self {
         DeQRError::EncodingError
     }
 }
 
-impl ::std::fmt::Display for DeQRError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for DeQRError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg = match self {
             DeQRError::IoError => "IoError(Could not write to output)",
             DeQRError::DataUnderflow => "DataUnderflow(Expected more bits to decode)",

--- a/src/prepare.rs
+++ b/src/prepare.rs
@@ -1,7 +1,9 @@
-use std::{cmp, num::NonZeroUsize};
-
 use crate::identify::match_capstones::CapStoneGroup;
 use crate::identify::Point;
+use alloc::boxed::Box;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::{cmp, num::NonZeroUsize};
 use lru::LruCache;
 
 /// An black-and-white image that can be mutated on search for QR codes

--- a/tests/test_errors.rs
+++ b/tests/test_errors.rs
@@ -2,10 +2,13 @@
 
 use rqrr::{DeQRError, PreparedImage};
 
+#[cfg(feature = "std")]
 use std::io::{Error, ErrorKind, Write};
 
+#[cfg(feature = "std")]
 struct BrokenWriter {}
 
+#[cfg(feature = "std")]
 impl Write for BrokenWriter {
     fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
         println!(
@@ -21,6 +24,7 @@ impl Write for BrokenWriter {
     }
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_io_error() {
     let img = image::open("tests/data/errors/io_error.png")


### PR DESCRIPTION
This will allow to use it on different targets which don’t have the `std` crate available.

I’ve reimplemented an extremely simple `std::io::Write` around `Vec<u8>`, which makes this crate support only this writer in `no_std` mode, but it should be possible to implement our custom `Write` trait manually on other types if needed.